### PR TITLE
fix(gomod): rewrite import paths and tidy on Go major bumps

### DIFF
--- a/default.json
+++ b/default.json
@@ -17,6 +17,7 @@
   "pruneStaleBranches": true,
   "rollbackPrs": true,
   "rangeStrategy": "bump",
+  "postUpdateOptions": ["gomodUpdateImportPaths", "gomodTidy"],
   "dependencyDashboard": true,
   "dependencyDashboardTitle": "Organization Security & Dependency Overview",
   "dependencyDashboardAutoclose": true,


### PR DESCRIPTION
Adds `postUpdateOptions: ["gomodUpdateImportPaths", "gomodTidy"]` to the default preset.

### The problem

Without these options, a Go **major** version bump produces a PR that is silently a no-op. Renovate adds the new module to `go.mod` as a require, but leaves every `import` statement pointing at the old major version — it has no way to rewrite import paths on its own.

The result compiles, tests pass, and CI goes fully green, because:

- the old major is still imported and still works
- the new major is required but imported by nothing
- `go.sum` therefore carries only the new module's `/go.mod` hash and **no `h1:` zip hash** — Go never downloaded the module body
- nothing in a typical `make check` runs `go mod tidy`, which would delete the require outright

So the PR looks like a clean dependency upgrade and delivers none of it.

### Seen in the wild

DragonSecurity/gomgr#101 (`go-github` v88 → v89): v89 added alongside v88, all 9 import sites untouched, 7/7 checks passing. Closed in favour of DragonSecurity/gomgr#107, which did the migration by hand.

### The fix

- `gomodUpdateImportPaths` rewrites import paths across the repo on major bumps
- `gomodTidy` drops the superseded require and keeps `go.sum` accurate

This affects every repo extending this preset. Go major bumps will still land as manual-review PRs (the existing `matchUpdateTypes: ["major"]` rule sets `automerge: false`), they will just contain the actual migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)