### PR TITLE
feat: track gomgr releases via .gomgr-version custom manager

### DIFF
--- a/default.json
+++ b/default.json
@@ -74,11 +74,23 @@
       "groupName": "Monthly major upgrades"
     }
   ],
-  "kubernetes": {                                                                                                                                                                                    
+  "kubernetes": {
+    "managerFilePatterns": [
+      "/(^|/)apps/.+\\.ya?ml$/",
+      "/(^|/)infrastructure/.+\\.ya?ml$/",
+      "/(^|/)clusters/.+\\.ya?ml$/"
+    ]
+  },
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Track gomgr release version (single source of truth in .gomgr-version)",
       "managerFilePatterns": [
-        "/(^|/)apps/.+\\.ya?ml$/",                                                                                                                                                                     
-        "/(^|/)infrastructure/.+\\.ya?ml$/",                                                                                                                                                           
-        "/(^|/)clusters/.+\\.ya?ml$/"                                                                                                                                                                  
-      ]                                                                                                                                                                                                
-    }  
+        "/^\\.gomgr-version$/"
+      ],
+      "matchStrings": ["(?<currentValue>v\\d+\\.\\d+\\.\\d+)"],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "DragonSecurity/gomgr"
+    }
+  ]
 }


### PR DESCRIPTION
Adds a `customManagers` entry to `default.json` so Renovate keeps a repo's `.gomgr-version` pin current from the shared preset instead of a per-repo config.

## Why

`internal-DragonSecurity/github-user-management` pins the gomgr version it runs in `.gomgr-version` and carries this manager locally in its own `.github/renovate.json`. That local copy is the only thing blocking that org from enabling `reconcile: true` on its gomgr-managed renovate config — with reconcile on, the sync would rewrite the file to the shared content and gomgr release tracking would silently stop.

Moving the manager here lets the repo inherit the preset cleanly.

## Blast radius

None outside that one repo. A `customManager` whose `managerFilePatterns` match no files is inert, and a code search across the orgs finds exactly one `.gomgr-version`:

```
repos with .gomgr-version: internal-DragonSecurity/github-user-management
```

So it does nothing in the other 71 managed repos, and becomes a free convention for any repo that later adopts the file.

## Also in this diff

The adjacent `kubernetes` block had inconsistent indentation and a long trail of trailing whitespace on most of its lines. Normalized — no semantic change, and the three `managerFilePatterns` are byte-identical.

## Follow-up

Once this merges, `dragonsecurity/internal-DragonSecurity/app.yaml` in `internal-DragonSecurity/github-user-management` flips to `reconcile: true`, and the three repos there that carry local renovate customization drop it. The other two (`homelab-gitops`, `nexus`) need no preset change at all — their "customizations" are already-inherited copies of `config:recommended` and this file's `kubernetes` block.

Order matters: this must merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)