### PR TITLE
fix: automerge through pull requests, not branch pushes

### DIFF
--- a/default.json
+++ b/default.json
@@ -32,7 +32,7 @@
   "lockFileMaintenance": {
     "enabled": true,
     "automerge": true,
-    "automergeType": "branch"
+    "automergeType": "pr"
   },
   "vulnerabilityAlerts": {
     "enabled": true,
@@ -50,13 +50,13 @@
       "minimumReleaseAge": "3 days",
       "ignoreTests": false,
       "automerge": true,
-      "automergeType": "branch"
+      "automergeType": "pr"
     },
     {
       "description": "Instant branch-based updates for ultra-low-risk internal maintenance",
       "matchUpdateTypes": ["pin", "digest", "lockFileMaintenance"],
       "automerge": true,
-      "automergeType": "branch",
+      "automergeType": "pr",
       "minimumReleaseAge": null
     },
     {


### PR DESCRIPTION
## The problem

`automergeType: "branch"` waits for a green status **on the Renovate branch**. Almost no repository in the estate produces one — CI is triggered by `pull_request` and `push` to the default branch, so a branch with no PR collects zero check runs and never becomes eligible. Renovate states this plainly on every dashboard:

> **Pending Branch Automerge** — The following updates await pending status checks before automerging. To abort the branch automerge and create a PR instead, click on a checkbox below.

## Measured, not assumed

| Org | Renovate branches | No PR at all |
| --- | --- | --- |
| DragonSecurity | 179 | 30 |
| dragonsecurity-incubating | 115 | 24 |
| internal-DragonSecurity | 172 | 8 |
| Decoupled-Saas | 36 | 0 |
| dragonsecurity-eye | 18 | 0 |
| **Total** | **520** | **62** |

The 62 are exactly the update types these rules mark `automerge: true` + `automergeType: "branch"` — `pin-dependencies`, `minor/patch-*-non-major`, digests. The two clean orgs are not configured differently: 31 of Decoupled-Saas's 36 branches are `major-*`, which the last rule already routes to a PR.

`prNotPendingHours: 12` should escalate these and sometimes does, but not reliably — stranded branches include one at 16 days (`blackstone`) and one at **106 days** (`eyrie`).

## Why this is a security issue, not a hygiene one

`DragonSecurity/pgmgr` is sitting on `renovate/go-golang.org-x-text-vulnerability` — *"update module golang.org/x/text to v0.39.0 **[security]**"* — with zero check runs and no PR, in a repository that has no workflows at all. `vulnerabilityAlerts.automerge` and `osvVulnerabilityAlerts.automerge` are both enabled in this preset. The delivery mechanism underneath them silently swallows the result.

## Why PR automerge is the right fix

- **This file already assumes it.** `platformAutomerge: true` is set, and that setting only means anything for PR automerge. The config is half-migrated already.
- **It is the only variant compatible with our own guardrails.** The `require-dco` ruleset gomgr applies to every default branch requires the `DCO` status check — which the Probot app reports only on a pull request — plus a `Signed-off-by:` commit-message pattern. A branch push can never satisfy the first.
- **It is already proven in this estate.** `DragonSecurity/apikit#6` was merged by `app/renovate` with GitHub native auto-merge, and its squash commit `7b12fcd` carries the `Signed-off-by:` trailer — both ruleset conditions met, unattended, by exactly this path.

Nothing is loosened: `minimumReleaseAge`, `ignoreTests: false` and the major-update review gate are unchanged. The updates simply become visible and mergeable instead of silently parked.

## Follow-up, not in this PR

`matchPackagePatterns` (line 49) is deprecated in current Renovate in favour of `matchPackageNames` with glob syntax. Worth checking the dashboards for a deprecation warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)