### PR TITLE
feat: stop managing dependencies inside generator templates

### DIFF
--- a/default.json
+++ b/default.json
@@ -45,6 +45,11 @@
   },
   "packageRules": [
     {
+      "description": "Generator templates are scaffold owned by the projects they generate, not dependencies of the repository holding them. A digest pinned here is baked into every project generated afterwards and cannot be updated without regenerating, so a base-image CVE never reaches them.",
+      "matchFileNames": ["internal/generator/templates/**"],
+      "enabled": false
+    },
+    {
       "description": "Global safety: Wait 3 days before any automerge and require passing CI",
       "matchPackagePatterns": ["*"],
       "minimumReleaseAge": "3 days",


### PR DESCRIPTION
## What this is

apikit's dependency dashboard lists this as a detected dependency:

> **dockerfile (1)** → `internal/generator/templates/Dockerfile.tmpl` (2)
> - `golang 1.26-alpine`
> - `gcr.io/distroless/static-debian12 nonroot` → Updates: `nonroot`

and has an open branch offering to pin that base image to a digest.

That file is not a dependency of apikit. It is the Dockerfile that **every project apikit generates** receives a copy of, and once generated the copy belongs to the generated project.

## Why pinning it is backwards

A digest pinned in the template means each generated project is born frozen to whatever the base image was the day its template was rendered. Renovate bumping the template afterwards only helps projects generated *after* the bump — the ones already in the wild keep the stale digest until a human notices. With the floating `nonroot` tag they pick up base-image fixes on their next rebuild, for free.

apikit's own tier test for this: *would a security fix need to reach existing projects without regenerating?* For a base-image CVE it plainly does.

## Scope

Scoped by path, so it is inert in the hundred-odd repositories with no such directory. apikit is currently the only repo that has one — `dragon-starter-prisma` and `template-go-api` are whole-repository templates, so their Dockerfiles *are* real dependencies of a real project and stay managed. Only the two template entries above stop being offered; apikit's own `go.mod`, `.github/workflows/ci.yml` and everything else remain covered.

## Why here and not in apikit's renovate.json

`internal-DragonSecurity/github-user-management` → `dragonsecurity/dragonsecurity/app.yaml` declares `.github/renovate.json` with `reconcile: true`, so gomgr rewrites that file across the org to a fixed two-line body. A local override in apikit would be reverted on the next sync — that is what the `chore: sync Renovate config` commits in repo histories are.

## Merge order

Touches the same `packageRules` array as #7, in a different hunk, so the two apply independently. If GitHub reports a conflict, #7 should land first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)