### PR TITLE
fix: clear every error and migration the Renovate validator reports

### DIFF
--- a/default.json
+++ b/default.json
@@ -12,7 +12,6 @@
   ],
   "rebaseWhen": "auto",
   "recreateWhen": "auto",
-  "recreateClosed": true,
   "prNotPendingHours": 12,
   "pruneStaleBranches": true,
   "rollbackPrs": true,
@@ -39,10 +38,7 @@
     "automerge": true,
     "addLabels": ["security", "automated-fix"]
   },
-  "osvVulnerabilityAlerts": {
-    "enabled": true,
-    "automerge": true
-  },
+  "osvVulnerabilityAlerts": true,
   "packageRules": [
     {
       "description": "Generator templates are scaffold owned by the projects they generate, not dependencies of the repository holding them. A digest pinned here is baked into every project generated afterwards and cannot be updated without regenerating, so a base-image CVE never reaches them.",
@@ -51,7 +47,7 @@
     },
     {
       "description": "Global safety: Wait 3 days before any automerge and require passing CI",
-      "matchPackagePatterns": ["*"],
+      "matchPackageNames": ["*"],
       "minimumReleaseAge": "3 days",
       "ignoreTests": false,
       "automerge": true,
@@ -67,7 +63,7 @@
     {
       "description": "Group non-major updates and enable automerge",
       "matchManagers": ["npm", "pnpm", "yarn", "gomod", "pip_requirements", "cargo"],
-      "excludeUpdateTypes": ["major"],
+      "matchUpdateTypes": ["minor", "patch"],
       "groupName": "{{{manager}}} non-major updates",
       "automerge": true
     },


### PR DESCRIPTION
Ran `renovate-config-validator` against the preset. It reports two hard errors and two auto-migrations. All four are fixed here; the file now validates clean.

## Hard errors — options Renovate rejects outright

```
Configuration option `osvVulnerabilityAlerts` should be boolean.
  Found: {"enabled":true,"automerge":true} (object)

Invalid configuration option: packageRules[3].excludeUpdateTypes
```

Both failed silently, which is what makes them worth fixing rather than tidying:

- **`osvVulnerabilityAlerts`** was declared as an object, so the OSV vulnerability source was never actually configured by this preset. It becomes the boolean it is defined as. Automerge for security updates keeps coming from `vulnerabilityAlerts`, which is already set and valid.
- **`excludeUpdateTypes`** is not a valid option, so the *"Group non-major updates"* rule was **not excluding majors**. It only behaved correctly because the rule after it sets `automerge: false` for majors and wins on ordering. Replaced with `matchUpdateTypes: ["minor", "patch"]`, which is what the description always claimed.

## Auto-migrations — work today, until they don't

- `matchPackagePatterns: ["*"]` → `matchPackageNames: ["*"]`
- `recreateClosed: true` → dropped; superseded by `recreateWhen`, already set to `auto`

## A note on validator version

Checked against **44.32.5**, not the older copy `npx` resolves by default. This matters: a **37.x** validator additionally rejects `kubernetes.managerFilePatterns` and the `pnpm`/`yarn` managers — both of which are valid on current Renovate. Acting on that older output would have been a regression, so those are deliberately untouched.

## Result

```
INFO: Validating default.json as global config
INFO: Config validated successfully against 1 file(s)
```

No errors, no migration diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)